### PR TITLE
Add worker registration

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -18,14 +18,15 @@ func main() {
 	// The command line arguments. args[0] is the name of the program.
 	args := os.Args
 
-	// If there was no argument passed, ask for one and exit.
-	if len(args) == 1 {
-		fmt.Println("Please pass a file name to send to the server.")
+	// If the right number of arguments weren't passed, ask for them and exit.
+	if len(args) != 3 {
+		fmt.Println("Please pass the address of the supervisor and a file to run.")
+		fmt.Println("Example: http://stu.cs.jmu.edu:4001 fun_code.py")
 		os.Exit(1)
 	}
 
 	// Open the file whose name was passed as an argument.
-	code, err := ioutil.ReadFile(args[1])
+	code, err := ioutil.ReadFile(args[2])
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +35,7 @@ func main() {
 	jobBytes := data.JobDataToJson(1, time.Now(), 2, 1, 10, code)
 
 	// Send a post request to the worker.
-	resp, err := http.Post("http://127.0.0.1:39480/newjob",
+	resp, err := http.Post(args[1]+"/newjob",
 		"text/plain", bytes.NewReader(jobBytes))
 	if err != nil {
 		panic(err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/showalter/bdws/internal/data"
 )
@@ -73,19 +75,32 @@ func new_job(w http.ResponseWriter, req *http.Request) {
 // The entry point of the program.
 func main() {
 
-	// The command line arguments. args[0] is the port to run on.
+	// The command line arguments. args[1] is the supervisor address,
+	// args[2] is the port to run on
 	args := os.Args
 
-	// If there was no argument passed, ask for one and exit.
-	if len(args) == 1 {
-		fmt.Println("Please pass a port number. Eg. :38471")
+	// If the right number of arguments weren't passed, ask for them.
+	if len(args) != 3 {
+		fmt.Println("Please pass the hostname of the supervisor and the outgoing port." +
+			"eg. http://stu.cs.jmu.edu:4001 4031")
 		os.Exit(1)
 	}
+
+	resp, err := http.Post(args[1] + "/register", "text/plain", strings.NewReader(args[2]))
+	if err != nil {
+		panic(err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+
+	// This gives what the supervisor thinks the worker is, which is useful for debugging.
+	_ = data.JsonToWorker(buf.Bytes())
 
 	// If there is a request for /newjob,
 	// the new_job routine will handle it.
 	http.HandleFunc("/newjob", new_job)
 
 	// Listen on a port.
-	http.ListenAndServe(args[1], nil)
+	log.Fatal(http.ListenAndServe(":"+args[2], nil))
 }

--- a/internal/data/save_object.go
+++ b/internal/data/save_object.go
@@ -110,3 +110,53 @@ func JsonToJob(b []byte) Job {
     }
     return j
 }
+
+type Worker struct {
+    Id int64
+    Busy bool
+	Hostname string
+}
+
+/**
+ * Saves a Worker information into json
+ */
+ func WorkerToJson(worker Worker) []byte{
+
+    // Save c as json byte array
+    b, err := json.Marshal(worker)
+
+    // Exit on error, otherwise return b
+    if err != nil {
+        log.Println(err)
+        os.Exit(-1)
+    }
+    return b
+}
+
+/**
+ * Saves a Worker information into json
+ */
+ func WorkerDataToJson(id int64, busy bool, hostname string) []byte{
+
+    // Create Worker Object
+    w := Worker{id, busy, hostname}
+
+    return WorkerToJson(w)
+}
+
+/**
+ * Coverts a []byte of json into a Worker struct
+ */
+func JsonToWorker(b []byte) Worker {
+    var w Worker
+
+    // Unmarshall b into Worker w
+    err := json.Unmarshal(b, &w)
+
+    // Exit on error, otherwise return j
+    if err != nil {
+        log.Println(err)
+        os.Exit(-1)
+    }
+    return w
+}


### PR DESCRIPTION
Note this changes how the programs must be called.

Supervisor (now must be run first): `./supervisor :4001`
Worker: `./worker http://127.0.0.1:4001 4002`
Client: `./client http://127.0.0.1:4001 test.sh`