### PR TITLE
Implement nruns, clean up int64/int inconsistencies

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -23,10 +23,10 @@ func main() {
 	// Declare variables
 	var hostName string
 	var fullFileName string
-	var start int64
-	var end int64
+	var start int
+	var end int
 	var args []string
-	var runs int64
+	var runs int
 
 	// Parse command line
 	parseCommandLine(&hostName, &fullFileName, &start, &end, &args, &runs)
@@ -49,6 +49,8 @@ func main() {
 		}
 	}
 
+	fmt.Println("Runs: " + strconv.Itoa(runs))
+
 	// Make a job with the given code.
 	jobBytes := data.JobDataToJson(1, time.Now(), 2, start, end, fileName, extension, code, args, runs)
 
@@ -69,11 +71,11 @@ func main() {
 }
 
 /* ----- Helper functions ----- */
-func parseCommandLine(hostname *string, fullFileName *string, start *int64, end *int64, args *[]string, runs *int64) {
+func parseCommandLine(hostname *string, fullFileName *string, start *int, end *int, args *[]string, runs *int) {
 	// Optional flags
 	argsPtr := flag.String("args", "NONE", "Command line args for file\nExample: -args \"-al\" when running ls")
 	rangePtr := flag.String("range", "NONE", "Range for job\nExample: -range 1-10")
-	runs = flag.Int64("runs", 1, "Number of times to run job")
+	runsPtr := flag.Int("runs", 1, "Number of times to run job")
 	flag.Parse()
 
 	*args = strings.Split(*argsPtr, " ")
@@ -98,6 +100,8 @@ func parseCommandLine(hostname *string, fullFileName *string, start *int64, end 
 	*start = 0
 	*end = -1
 
+	*runs = *runsPtr
+
 	var err error
 
 	// Get range if specified with flag
@@ -108,10 +112,10 @@ func parseCommandLine(hostname *string, fullFileName *string, start *int64, end 
 			os.Exit(1)
 		}
 
-		*start, err = strconv.ParseInt(split[0], 10, 64)
+		*start, err = strconv.Atoi(split[0])
 		check(err)
 
-		*end, err = strconv.ParseInt(split[1], 10, 64)
+		*end, err = strconv.Atoi(split[1])
 		check(err)
 	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/showalter/bdws/internal/data"
 )
 
-type codeFunction func([]byte, string, *int64, []string) []byte
+type codeFunction func([]byte, string, *int, []string) []byte
 
 // Map various extension names to their code
 var extensionMap = map[string]codeFunction{
@@ -31,7 +31,7 @@ var extensionMap = map[string]codeFunction{
 var workerDirectory string
 
 // run the code given an extension
-func runCode(e string, code []byte, fn string, num *int64, args []string) []byte {
+func runCode(e string, code []byte, fn string, num *int, args []string) []byte {
 	f, found := extensionMap[e]
 	if found {
 		return f(code, fn, num, args)
@@ -74,7 +74,7 @@ func new_job(w http.ResponseWriter, req *http.Request) {
 	// Convert string json to job struct
 	job := data.JsonToJob([]byte(jobJson))
 
-	var num *int64 = nil
+	var num *int = nil
 
 	if job.ParameterEnd >= job.ParameterStart {
 		num = &job.ParameterStart
@@ -149,7 +149,7 @@ func createFile(name string, code []byte) {
 }
 
 // Run a bash script / script
-func script(code []byte, fileName string, num *int64, args []string) []byte {
+func script(code []byte, fileName string, num *int, args []string) []byte {
 
 	var output []byte
 
@@ -163,7 +163,7 @@ func script(code []byte, fileName string, num *int64, args []string) []byte {
 
 	// Execute temp file.
 	if num != nil {
-		args = append([]string{strconv.FormatInt(*num, 10)}, args...)
+		args = append([]string{strconv.Itoa(*num)}, args...)
 	}
 	output = run(fullName, args...)
 
@@ -171,7 +171,7 @@ func script(code []byte, fileName string, num *int64, args []string) []byte {
 }
 
 // Run a .class file
-func javaClass(code []byte, fileName string, num *int64, args []string) []byte {
+func javaClass(code []byte, fileName string, num *int, args []string) []byte {
 
 	var output []byte
 
@@ -182,7 +182,7 @@ func javaClass(code []byte, fileName string, num *int64, args []string) []byte {
 
 	// Execute temp file.
 	if num != nil {
-		args = append([]string{strconv.FormatInt(*num, 10)}, args...)
+		args = append([]string{strconv.Itoa(*num)}, args...)
 	}
 
 	args = append([]string{"-cp", workerDirectory, strings.Split(fileName, ".")[0]}, args...)
@@ -192,7 +192,7 @@ func javaClass(code []byte, fileName string, num *int64, args []string) []byte {
 }
 
 // Run a .java file
-func javaFile(code []byte, fileName string, num *int64, args []string) []byte {
+func javaFile(code []byte, fileName string, num *int, args []string) []byte {
 
 	fullName := workerDirectory + "/" + fileName
 
@@ -229,7 +229,7 @@ func javaFile(code []byte, fileName string, num *int64, args []string) []byte {
 }
 
 // Run a jar file
-func jarFile(code []byte, fileName string, num *int64, args []string) []byte {
+func jarFile(code []byte, fileName string, num *int, args []string) []byte {
 
 	var output []byte
 
@@ -241,7 +241,7 @@ func jarFile(code []byte, fileName string, num *int64, args []string) []byte {
 	// Execute temp file.
 
 	if num != nil {
-		args = append([]string{strconv.FormatInt(*num, 10)}, args...)
+		args = append([]string{strconv.Itoa(*num)}, args...)
 	}
 
 	args = append([]string{"-jar", fullName}, args...)
@@ -251,7 +251,7 @@ func jarFile(code []byte, fileName string, num *int64, args []string) []byte {
 }
 
 // Run a python script
-func pythonScript(code []byte, fileName string, num *int64, args []string) []byte {
+func pythonScript(code []byte, fileName string, num *int, args []string) []byte {
 
 	var output []byte
 
@@ -262,7 +262,7 @@ func pythonScript(code []byte, fileName string, num *int64, args []string) []byt
 
 	// Execute temp script.
 	if num != nil {
-		args = append([]string{strconv.FormatInt(*num, 10)}, args...)
+		args = append([]string{strconv.Itoa(*num)}, args...)
 	}
 	args = append([]string{fullName}, args...)
 	output = run("python3", args...)
@@ -271,13 +271,14 @@ func pythonScript(code []byte, fileName string, num *int64, args []string) []byt
 }
 
 // Run a system program
-func system_program(code []byte, fileName string, num *int64, args []string) []byte {
+func system_program(code []byte, fileName string, num *int, args []string) []byte {
 
 	var output []byte
 
 	if num != nil {
-		args = append([]string{strconv.FormatInt(*num, 10)}, args...)
+		args = append([]string{strconv.Itoa(*num)}, args...)
 	}
+
 	output = run(fileName, args...)
 
 	return output

--- a/internal/data/save_object.go
+++ b/internal/data/save_object.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Client struct {
-	Id   int64
+	Id   int
 	Time time.Time
 }
 
@@ -32,7 +32,7 @@ func ClientToJson(client Client) []byte {
 /**
  * Saves a client's information into json
  */
-func ClientDataToJson(id int64, time time.Time) []byte {
+func ClientDataToJson(id int, time time.Time) []byte {
 
 	// Create Client Object
 	c := Client{id, time}
@@ -58,16 +58,16 @@ func JsonToClient(b []byte) Client {
 }
 
 type Job struct {
-	Id             int64
+	Id             int
 	Time           time.Time
-	Machines       int64
-	ParameterStart int64
-	ParameterEnd   int64
+	Machines       int
+	ParameterStart int
+	ParameterEnd   int
 	FileName       string
 	Extension      string
 	Code           []byte
 	Args           []string
-	Nruns          int64
+	Nruns          int
 }
 
 /**
@@ -89,8 +89,8 @@ func JobToJson(job Job) []byte {
 /**
  * Saves a Job information into json
  */
-func JobDataToJson(id int64, time time.Time, machines int64,
-	parameterStart int64, parameterEnd int64, fileName string, extension string, code []byte, args []string, nruns int64) []byte {
+func JobDataToJson(id int, time time.Time, machines int,
+	parameterStart int, parameterEnd int, fileName string, extension string, code []byte, args []string, nruns int) []byte {
 
 	// Create Job Object
 	j := Job{id, time, machines, parameterStart, parameterEnd, fileName, extension, code, args, nruns}


### PR DESCRIPTION
Example for nruns: `./client -runs 5 -args "+%N" host date`

You should get multiple distinct numbers. It's possible to get less than 5, but there should certainly be more than one, especially if there are few workers.

